### PR TITLE
point at mapserv instead of relative path

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,7 +30,7 @@ jobs:
 
       - run: bower install
 
-      - run: grunt build-prod
+      - run: grunt build-stage
 
       - name: Firebase Deploy
         uses: FirebaseExtended/action-hosting-deploy@v0

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,7 +4,7 @@ on:
   push:
     paths:
       - "src/**"
-      - ".github/workflows/nodejs.yaml"
+      - ".github/workflows/nodejs.yml"
       - "package.json"
 
 jobs:

--- a/src/app/config.js
+++ b/src/app/config.js
@@ -47,9 +47,9 @@ define([
         window.AGRC.apiKey = 'AGRC-4DD66766986896';
         window.AGRC.quadWord = 'alfred-plaster-crystal-dexter';
     } else if (has('agrc-build') === 'stage') {
-        // test.mapserv.utah.gov
+        // *.dev.utah.gov
         window.AGRC.apiKey = 'AGRC-AC122FA9671436';
-        window.AGRC.quadWord = 'opera-event-little-pinball';
+        window.AGRC.quadWord = 'wedding-tactic-enrico-yes';
     } else {
         // localhost
         window.AGRC.apiKey = 'AGRC-E5B94F99865799';

--- a/src/app/config.js
+++ b/src/app/config.js
@@ -35,8 +35,7 @@ define([
         apiKey: '', // acquire at developer.mapserv.utah.gov
 
         urls: {
-            parcel: window.location.protocol + '//' +
-                    window.location.hostname + '/arcgis/rest/services/Parcels/Mapserver',
+            parcel: 'https://mapserv.utah.gov/arcgis/rest/services/Parcels/Mapserver',
             exportWebMapUrl: 'https://print.agrc.utah.gov/5/arcgis/rest/services/GPServer/export'
         },
 

--- a/src/app/config.js
+++ b/src/app/config.js
@@ -48,7 +48,7 @@ define([
         window.AGRC.quadWord = 'alfred-plaster-crystal-dexter';
     } else if (has('agrc-build') === 'stage') {
         // *.dev.utah.gov
-        window.AGRC.apiKey = 'AGRC-AC122FA9671436';
+        window.AGRC.apiKey = 'AGRC-FE1B257E901672';
         window.AGRC.quadWord = 'wedding-tactic-enrico-yes';
     } else {
         // localhost


### PR DESCRIPTION
mapserv used to be the same as parcels.utah.gov so these relative paths worked. We not need to be more explicit when the domain and website are in the cloud.